### PR TITLE
Fix translation in `Lattice`

### DIFF
--- a/flowermd/base/system.py
+++ b/flowermd/base/system.py
@@ -769,7 +769,9 @@ class Lattice(System):
                 try:
                     comp1 = self.all_molecules[next_idx]
                     comp2 = self.all_molecules[next_idx + 1]
-                    comp2.translate(self.basis_vector)
+                    comp2.translate(
+                            self.basis_vector * np.array([self.x, self.y, 0])
+                    )
                     # TODO: what if comp1 and comp2 have different names?
                     unit_cell = mb.Compound(
                         subcompounds=[comp1, comp2], name=comp1.name

--- a/flowermd/base/system.py
+++ b/flowermd/base/system.py
@@ -770,7 +770,7 @@ class Lattice(System):
                     comp1 = self.all_molecules[next_idx]
                     comp2 = self.all_molecules[next_idx + 1]
                     comp2.translate(
-                            self.basis_vector * np.array([self.x, self.y, 0])
+                        self.basis_vector * np.array([self.x, self.y, 0])
                     )
                     # TODO: what if comp1 and comp2 have different names?
                     unit_cell = mb.Compound(


### PR DESCRIPTION
I found a box where the translation of the 2nd chain in the unit cell of  `Lattice` was not being translated correctly. This should fix that