### PR TITLE
Fix `PEKK`, remove `random_sequence` parameter from `CoPolymer`

### DIFF
--- a/flowermd/base/molecule.py
+++ b/flowermd/base/molecule.py
@@ -506,8 +506,6 @@ class CoPolymer(Molecule):
         Manually define the sequence of 'A' and 'B' monomers.
         Leave as None if generating random sequences.
         Example: sequence = "AABAABAAB"
-    random_sequence : bool, default False
-        Creates a random 'A' 'B' sequence as a function of the AB_ratio.
     AB_ratio : float, default 0.50
         The relative weight of A to B monomer types.
         Used when generating random sequences.
@@ -524,7 +522,6 @@ class CoPolymer(Molecule):
         num_mols,
         force_field=None,
         sequence=None,
-        random_sequence=False,
         AB_ratio=0.50,
         seed=24,
     ):
@@ -535,7 +532,10 @@ class CoPolymer(Molecule):
         if len(num_mols) != len(self.lengths):
             raise ValueError("Number of molecules and lengths must be equal.")
         self.sequence = sequence
-        self.random_sequence = random_sequence
+        if not self.sequence:
+            self.random_sequence = True
+        else:
+            self.random_sequence = False
         self.AB_ratio = AB_ratio
         self.seed = seed
         self._A_count = 0

--- a/flowermd/library/polymers.py
+++ b/flowermd/library/polymers.py
@@ -97,8 +97,8 @@ class PEEK(Polymer):
 class PEKK(CoPolymer):
     """Create a Poly(ether-ketone-ketone) (PEKK) chain.
 
-    The CoPolymer class is used to create a polymer chain with two different
-    monomer types, represented by the para and meta isomeric forms of PEKK.
+    Creates a polymer chain with two different monomer types,
+    represented by the para (T) and meta (I) isomeric forms of PEKK.
 
     Parameters
     ----------
@@ -106,8 +106,10 @@ class PEKK(CoPolymer):
         The number of monomer repeat units in the chain.
     num_mols : int, required
         The number of chains to create.
-    random_sequence : bool, default False
-        Creates a random 'A' 'B' sequence as a function of the AB_ratio.
+    sequence : str, default None
+        Manually define the sequence of para (T) and meta (I) monomers.
+        Leave as None if generating random sequences.
+        Example: sequence = "TTITTITTI"
     TI_ratio : float, required
         The ratio of meta to para isomers in the chain.
 
@@ -119,7 +121,6 @@ class PEKK(CoPolymer):
         num_mols,
         force_field=None,
         sequence=None,
-        random_sequence=False,
         TI_ratio=0.50,
         seed=24,
     ):
@@ -130,7 +131,6 @@ class PEKK(CoPolymer):
             num_mols=num_mols,
             force_field=force_field,
             sequence=sequence,
-            random_sequence=random_sequence,
             AB_ratio=TI_ratio,
             seed=seed,
         )

--- a/flowermd/tests/base/test_molecule.py
+++ b/flowermd/tests/base/test_molecule.py
@@ -244,6 +244,7 @@ class TestCopolymer(BaseTest):
             sequence="ABA",
         )
         assert copolymer.n_particles == 22
+        assert copolymer.random_sequence is False
         assert ("C", "C", "C", "C") in copolymer.topology_information[
             "dihedral_types"
         ]
@@ -283,7 +284,6 @@ class TestCopolymer(BaseTest):
             monomer_B=polyethylene,
             lengths=[3],
             num_mols=[1],
-            random_sequence=True,
             seed=42,
         )
         # sequence is BAA

--- a/flowermd/tests/library/test_polymers.py
+++ b/flowermd/tests/library/test_polymers.py
@@ -3,6 +3,7 @@ import pytest
 
 from flowermd.library import (
     PEEK,
+    PEKK,
     PPS,
     LJChain,
     PEKK_meta,
@@ -26,6 +27,11 @@ class TestPolymers:
         chain = PEKK_meta(lengths=5, num_mols=1)
         monomer = mb.load(chain.smiles, smiles=True)
         assert chain.n_particles == (monomer.n_particles * 5) - 8
+
+    def test_pekk(self):
+        chain = PEKK(lengths=5, num_mols=1, TI_ratio=0.50)
+        assert chain.random_sequence is True
+        assert chain.AB_ratio == 0.50
 
     def test_pekk_para(self):
         chain = PEKK_para(lengths=5, num_mols=1)


### PR DESCRIPTION
This PR removes `random_sequence` as a parameter when initializing a `CoPolymer`. Instead, `random_sequence` is set based on what is given for `sequence` when initializing a `CoPolymer`