### PR TITLE
Update `environment.yml` to use conda-forge versions of `grits` and `cmeutils`

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -2,13 +2,13 @@ name: flowermd
 channels:
   - conda-forge
 dependencies:
-  - boltons
   - foyer
   - fresnel
-  - freud>=2.13.1
-  - gsd>=3.0
-  - hoomd=4.1=*cpu*
-  - mbuild
+  - freud >=2.13.1
+  - gmso >=0.11.2
+  - gsd >=3.0
+  - hoomd=4.3=*cpu*
+  - mbuild >=0.16.4
   - numpy
   - openbabel
   - pip
@@ -16,12 +16,6 @@ dependencies:
   - pytest
   - pytest-cov
   - python=3.9
-  - unyt
-  - symengine
-  - python-symengine
-  - sympy
-  - fresnel
-  - pip:
-      - git+https://github.com/mosdef-hub/gmso.git@main
-      - git+https://github.com/cmelab/cmeutils.git@master
-      - git+https://github.com/cmelab/grits.git@main
+  - fresnel >=0.13.5
+  - cmeutils >=0.0.3
+  - grits >=0.3.0

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -15,7 +15,7 @@ dependencies:
   - py3Dmol
   - pytest
   - pytest-cov
-  - python >=3.9
+  - python >=3.10
   - fresnel >=0.13.5
   - cmeutils >=1.0
   - grits >=0.3.0

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -15,7 +15,7 @@ dependencies:
   - py3Dmol
   - pytest
   - pytest-cov
-  - python=3.9
+  - python >=3.9
   - fresnel >=0.13.5
-  - cmeutils >=0.0.3
+  - cmeutils >=1.0
   - grits >=0.3.0

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -15,7 +15,7 @@ dependencies:
   - py3Dmol
   - pytest
   - pytest-cov
-  - python=3.9
+  - python >=3.10
   - fresnel >=0.13.5
-  - cmeutils >=0.0.3
+  - cmeutils >=1.0
   - grits >=0.3.0

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -2,13 +2,13 @@ name: flowermd
 channels:
   - conda-forge
 dependencies:
-  - boltons
   - foyer
   - fresnel
-  - freud>=2.13.1
-  - gsd>=3.0
-  - hoomd=4.1=*gpu*
-  - mbuild
+  - freud >=2.13.1
+  - gmso >=0.11.2
+  - gsd >=3.0
+  - hoomd=4.3=*gpu*
+  - mbuild >=0.16.4
   - numpy
   - openbabel
   - pip
@@ -16,12 +16,6 @@ dependencies:
   - pytest
   - pytest-cov
   - python=3.9
-  - unyt
-  - symengine
-  - python-symengine
-  - sympy
-  - fresnel
-  - pip:
-      - git+https://github.com/mosdef-hub/gmso.git@main
-      - git+https://github.com/cmelab/cmeutils.git@master
-      - git+https://github.com/cmelab/grits.git@main
+  - fresnel >=0.13.5
+  - cmeutils >=0.0.3
+  - grits >=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# Example copied with love from:
-# https://github.com/kennethreitz/setup.py/blob/master/setup.py
-
-# Note: To use the 'upload' functionality of this file, you must:
-#   $ pip install twine
-
 import os
 import sys
 from shutil import rmtree
@@ -16,7 +7,7 @@ from setuptools import Command, find_packages, setup
 # Package meta-data.
 NAME = "flowermd"
 DESCRIPTION = (
-    "Package making it easier to build and simulate polymers in Hoomd-Blue"
+    "Package making it easier to build and simulate polymers in Hoomd-Blue."
 )
 URL = "https://github.com/cmelab/flowerMD"
 EMAIL = "chrisjones4@u.boisestate.edu"
@@ -81,7 +72,6 @@ class UploadCommand(Command):
         sys.exit()
 
 
-# Where the magic happens:
 setup(
     name=NAME,
     version=about["__version__"],
@@ -96,11 +86,6 @@ setup(
             "docs",
         )
     ),
-    # If your package is a single module, use this instead of 'packages':
-    # py_modules=['mypackage'],
-    # entry_points={
-    #     'console_scripts': ['mycli=mymodule:cli'],
-    # },
     package_data={
         "flowermd": [
             "modules/*",
@@ -111,10 +96,8 @@ setup(
     },
     install_requires=REQUIRED,
     include_package_data=True,
-    license="MIT",
+    license="GPLv3",
     classifiers=[
-        # Trove classifiers
-        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
In preparation for making a conda-forge package for `flowermd` @marjanAlbouye and I updated the conda packages for both `grits` and `cmeutils`. This PR installs these packages from conda-forge rather than from source. I also pinned the latest version of hoomd and mosdef packages.