### PR TITLE
`Graphene` now inherits from `Molecule`

### DIFF
--- a/flowermd/base/molecule.py
+++ b/flowermd/base/molecule.py
@@ -31,7 +31,7 @@ class Molecule:
         Number of molecules to generate.
     force_field : flowermd.ForceField or a list of
         `hoomd.md.force.Force` objects, default=None
-        The force field to be applied to the molecule for parameterization.
+        The forcefield to be applied to the molecule for parameterization.
         Note that setting `force_field` does not actually apply the
         forcefield to the molecule. The forcefield in this step is mainly
         used for validation purposes.
@@ -430,8 +430,12 @@ class Polymer(Molecule):
         The smiles string of the monomer to generate.
     file : str, default None
         The file path to the monomer to generate.
-    force_field : str, default None
-        The force field to apply to the molecule.
+    force_field : flowermd.ForceField or a list of
+        `hoomd.md.force.Force` objects, default=None
+        The forcefield to be applied to the molecule for parameterization.
+        Note that setting `force_field` does not actually apply the
+        forcefield to the molecule. The forcefield in this step is mainly
+        used for validation purposes.
     bond_indices: list, default None
         The indices of the atoms to bond.
     bond_length: float, default None
@@ -502,6 +506,8 @@ class CoPolymer(Molecule):
         Class of the B-type monomer
     length : int, required
         The total number of monomers in the molecule
+    num_mols : int, required
+        Number of chains to generate.
     sequence : str, default None
         Manually define the sequence of 'A' and 'B' monomers.
         Leave as None if generating random sequences.
@@ -509,6 +515,12 @@ class CoPolymer(Molecule):
     AB_ratio : float, default 0.50
         The relative weight of A to B monomer types.
         Used when generating random sequences.
+    force_field : flowermd.ForceField or a list of
+        `hoomd.md.force.Force` objects, default=None
+        The forcefield to be applied to the molecule for parameterization.
+        Note that setting `force_field` does not actually apply the
+        forcefield to the molecule. The forcefield in this step is mainly
+        used for validation purposes.
     seed : int, default 24
         Set the seed used when generating random sequences
 

--- a/flowermd/library/surfaces.py
+++ b/flowermd/library/surfaces.py
@@ -1,10 +1,13 @@
 """Recipes to generate surfaces using mBuild."""
 
+import mbuild as mb
 from mbuild.compound import Compound
 from mbuild.lattice import Lattice
 
+from flowermd.base import Molecule
 
-class Graphene(Compound):
+
+class Graphene(Molecule):
     """Create a rectangular graphene layer or multiple layers.
 
     Parameters
@@ -28,9 +31,14 @@ class Graphene(Compound):
     """
 
     def __init__(
-        self, x_repeat, y_repeat, n_layers, periodicity=(True, True, False)
+        self,
+        x_repeat,
+        y_repeat,
+        n_layers,
+        force_field=None,
+        periodicity=(True, True, False),
     ):
-        super(Graphene, self).__init__(periodicity=periodicity)
+        surface = mb.Compound(periodicity=periodicity)
         spacings = [0.425, 0.246, 0.35]
         points = [[1 / 6, 0, 0], [1 / 2, 0, 0], [0, 0.5, 0], [2 / 3, 1 / 2, 0]]
         lattice = Lattice(
@@ -38,9 +46,12 @@ class Graphene(Compound):
             angles=[90, 90, 90],
             lattice_points={"A": points},
         )
-        carbon = Compound(name="C")
+        carbon = Compound(name="C", element="C")
         layers = lattice.populate(
             compound_dict={"A": carbon}, x=x_repeat, y=y_repeat, z=n_layers
         )
-        self.add(layers)
-        self.freud_generate_bonds("C", "C", dmin=0.14, dmax=0.145)
+        surface.add(layers)
+        surface.freud_generate_bonds("C", "C", dmin=0.14, dmax=0.145)
+        super(Graphene, self).__init__(
+            compound=surface, num_mols=1, force_field=force_field
+        )

--- a/flowermd/library/surfaces.py
+++ b/flowermd/library/surfaces.py
@@ -18,6 +18,11 @@ class Graphene(Molecule):
         Number of times to repeat graphene lattice in the y-direciton.
     n_layers: int, optional, default 1
         Number of times to repeat the complete layer in the normal direction.
+    force_field: force_field : flowermd.ForceField
+        The force field to be applied to the surface for paramaterizaiton.
+        Note that setting `force_field` does not actually apply the forcefield
+        to the molecule. The forcefield in this step is mainly used for
+        validation purposes.
     periodicity : tuple of bools, length=3, optional, default=(True, True, False) # noqa: E501
         Whether the Compound is periodic in the x, y, and z directions.
         If None is provided, the periodicity is set to `(False, False, False)`


### PR DESCRIPTION
Given some discussion with @marjanAlbouye about how to best design a surface wetting module, one of the first to-dos was making it so that the surfaces in `flowermd.library.surfaces` inherit from `flowermd.base.Molecule`.  This PR makes this change.

Here is an example of how we can create a graphene surface and apply a forcefield:

```
from flowermd.library import Graphene
from flowermd.library import OPLS_AA
from gmso.external import to_hoomd_snapshot, to_hoomd_forcefield

graphene = Graphene(
    x_repeat=4,
    y_repeat=4,
    n_layers=2,
    force_field=OPLS_AA()
)

graphene_snap = to_hoomd_snapshot(graphene.gmso_molecule)[0]
graph_ff = to_hoomd_forcefield(graphene.gmso_molecule, r_cut=2.5)[0]
```

This was the first step needed in order for the design choices we discussed in a class that combines a surface with a droplet GSD file.