### PR TITLE
fix setup.py to install all modules

### DIFF
--- a/flowermd/__version__.py
+++ b/flowermd/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 1, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     ),
     package_data={
         "flowermd": [
-            "modules/*",
+            "modules/**",
             "library/**",
             "assets/forcefields/*",
             "assets/molecule_files/*",


### PR DESCRIPTION
The surface wetting module wasn't installing, so this fixes `setup.py` to install all sub dirs in `flowermd/modules/`. 