### PR TITLE
Fix import for `add_void_particles` in `modules.welding.utils`

### DIFF
--- a/flowermd/modules/welding/__init__.py
+++ b/flowermd/modules/welding/__init__.py
@@ -1,3 +1,3 @@
 """Welding module for FlowerMD."""
-from .welding import Interface, SlabSimulation, WeldSimulation
 from .utils import add_void_particles
+from .welding import Interface, SlabSimulation, WeldSimulation

--- a/flowermd/modules/welding/__init__.py
+++ b/flowermd/modules/welding/__init__.py
@@ -1,2 +1,3 @@
 """Welding module for FlowerMD."""
 from .welding import Interface, SlabSimulation, WeldSimulation
+from .utils import add_void_particles


### PR DESCRIPTION
This is a quick PR that adds the `utils.py` file located in the welding module to `__init__.py` so that its funcitons can be imported.