### PR TITLE
Add type check for forcefield parameter in `Simulation`

### DIFF
--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -3,6 +3,7 @@
 import inspect
 import pickle
 import warnings
+from collections.abc import Iterable
 
 import gsd.hoomd
 import hoomd
@@ -67,6 +68,20 @@ class Simulation(hoomd.simulation.Simulation):
         log_file_name="sim_data.txt",
         thermostat=HOOMDThermostats.MTTK,
     ):
+        if not isinstance(forcefield, Iterable) and not isinstance(
+            forcefield, str
+        ):
+            raise ValueError(
+                "forcefield must be a sequence of "
+                "hoomd.md.force.Force objects."
+            )
+        else:
+            for obj in forcefield:
+                if not isinstance(obj, hoomd.md.force.Force):
+                    raise ValueError(
+                        "forcefield must be a sequence of "
+                        "hoomd.md.force.Force objects."
+                    )
         super(Simulation, self).__init__(device, seed)
         self.initial_state = initial_state
         self._forcefield = forcefield

--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -68,9 +68,7 @@ class Simulation(hoomd.simulation.Simulation):
         log_file_name="sim_data.txt",
         thermostat=HOOMDThermostats.MTTK,
     ):
-        if not isinstance(forcefield, Iterable) and not isinstance(
-            forcefield, str
-        ):
+        if not isinstance(forcefield, Iterable) or isinstance(forcefield, str):
             raise ValueError(
                 "forcefield must be a sequence of "
                 "hoomd.md.force.Force objects."

--- a/flowermd/tests/base/test_simulation.py
+++ b/flowermd/tests/base/test_simulation.py
@@ -369,6 +369,11 @@ class TestSimulate(BaseTest):
                 initial_state=benzene_system.hoomd_snapshot,
                 forcefield=OPLS_AA_PPS,
             )
+        with pytest.raises(ValueError):
+            Simulation(
+                initial_state=benzene_system.hoomd_snapshot,
+                forcefield=[1, 2, 3],
+            )
 
     def test_flush(self, benzene_system):
         sim = Simulation.from_system(benzene_system, gsd_write_freq=100)

--- a/flowermd/tests/base/test_simulation.py
+++ b/flowermd/tests/base/test_simulation.py
@@ -9,6 +9,7 @@ import pytest
 import unyt as u
 
 from flowermd import Simulation
+from flowermd.library import OPLS_AA_PPS
 from flowermd.tests import BaseTest
 from flowermd.utils import (  # get_target_box_number_density,
     get_target_box_mass_density,
@@ -357,6 +358,17 @@ class TestSimulate(BaseTest):
 
         os.remove("trajectory.gsd")
         os.remove("sim_data.txt")
+
+    def test_bad_ff(self, benzene_system):
+        with pytest.raises(ValueError):
+            Simulation(
+                initial_state=benzene_system.hoomd_snapshot, forcefield="gaff"
+            )
+        with pytest.raises(ValueError):
+            Simulation(
+                initial_state=benzene_system.hoomd_snapshot,
+                forcefield=OPLS_AA_PPS,
+            )
 
     def test_flush(self, benzene_system):
         sim = Simulation.from_system(benzene_system, gsd_write_freq=100)

--- a/flowermd/tests/base/test_system.py
+++ b/flowermd/tests/base/test_system.py
@@ -835,7 +835,7 @@ class TestSystem(BaseTest):
             auto_scale=True,
         )
         assert abs(no_scale.net_charge.value) > abs(with_scale.net_charge.value)
-        assert np.allclose(0, with_scale.net_charge.value, atol=1e-30)
+        assert np.allclose(0, with_scale.net_charge.value, atol=1e-13)
 
     def test_to_gsd(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)

--- a/flowermd/tests/utils/test_utils.py
+++ b/flowermd/tests/utils/test_utils.py
@@ -50,7 +50,7 @@ class TestUtils:
         density = u.unyt_quantity(0.5, u.g / u.cm**3)
         target_box = get_target_box_mass_density(density=density, mass=mass)
         assert target_box[0] == target_box[1] == target_box[2]
-        assert np.array_equal(target_box, np.array([2 * u.cm] * 3))
+        assert np.array_equal(target_box, np.array([2] * 3) * u.cm)
 
     def test_target_box_one_constraint_mass(self):
         mass = u.unyt_quantity(4.0, u.g)


### PR DESCRIPTION
This PR adds and error that is thrown if the  `forcefield` parameter of `Simulation` is not a sequence of `hoomd.md.force.Force` objects.