### PR TITLE
Bug fix in `Interface` to duplicate and shift along the correct axis

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - gmso >=0.11.2
   - gsd >=3.0
   - hoomd=4.3
-  - mbuild >=0.16.4
+  - mbuild >=0.17.0
   - numpy
   - openbabel >=3
   - pip
@@ -16,7 +16,7 @@ dependencies:
   - py3Dmol
   - pytest
   - pytest-cov
-  - python >=3.10
+  - python >=3.10, <3.12
   - fresnel >=0.13.5
   - cmeutils >=1.1.1
   - grits >=0.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,12 +8,12 @@ dependencies:
   - gmso >=0.11.2
   - gsd >=3.0
   - hoomd=4.3
-  - mbuild >=0.16.4
+  - mbuild >=0.17.0
   - numpy
   - openbabel >=3
   - pip
   - py3Dmol
-  - python >=3.10
+  - python >=3.10, <3.12
   - fresnel >=0.13.5
   - cmeutils >=1.1.1
   - grits >=0.3.0

--- a/flowermd/modules/welding/welding.py
+++ b/flowermd/modules/welding/welding.py
@@ -35,7 +35,7 @@ class Interface:
         remove_void_particles=True,
     ):
         self.gsd_files = check_return_iterable(gsd_files)
-        self.interface_axis = interface_axis
+        self.interface_axis = np.asarray(interface_axis)
         self.gap = gap
         self.wall_sigma = wall_sigma
         self._remove_void_particles = remove_void_particles
@@ -84,6 +84,7 @@ class Interface:
         # Set up box. Box edge is doubled along the interface axis direction,
         # plus the gap
         axis_index = np.where(self.interface_axis != 0)[0]
+        print("Axis index:", axis_index)
         interface.configuration.box = np.copy(snap_L.configuration.box)
         interface.configuration.box[axis_index] *= 2
         interface.configuration.box[axis_index] += self.gap - self.wall_sigma

--- a/flowermd/modules/welding/welding.py
+++ b/flowermd/modules/welding/welding.py
@@ -81,10 +81,8 @@ class Interface:
         interface.dihedrals.N = snap_L.dihedrals.N + snap_R.dihedrals.N
         interface.dihedrals.M = 4
         interface.pairs.N = snap_L.pairs.N + snap_R.pairs.N
-        # Set up box. Box edge is doubled along the interface axis direction,
-        # plus the gap
+        # Box edge is doubled along the interface axis plus the gap
         axis_index = np.where(self.interface_axis != 0)[0]
-        print("Axis index:", axis_index)
         interface.configuration.box = np.copy(snap_L.configuration.box)
         interface.configuration.box[axis_index] *= 2
         interface.configuration.box[axis_index] += self.gap - self.wall_sigma


### PR DESCRIPTION
This is a quick bug fix that changes `interface_axis` to a numpy array as the behavior of `np.where` was not working as expected on certain data types (e.g. tuples).