### PR TITLE
Fix `Lattice` system class for coarse-grained molecules

### DIFF
--- a/flowermd/base/molecule.py
+++ b/flowermd/base/molecule.py
@@ -3,8 +3,8 @@
 import itertools
 import os.path
 import random
-from typing import List
 import warnings
+from typing import List
 
 import mbuild as mb
 import numpy as np
@@ -223,7 +223,7 @@ class Molecule:
                 except AttributeError:
                     positions = mol.xyz
                     warnings.warn(
-                        "No element information found." 
+                        "No element information found."
                         "Using all particle positions to fit backbone axis."
                     )
             else:

--- a/flowermd/base/molecule.py
+++ b/flowermd/base/molecule.py
@@ -4,6 +4,7 @@ import itertools
 import os.path
 import random
 from typing import List
+import warnings
 
 import mbuild as mb
 import numpy as np
@@ -211,13 +212,20 @@ class Molecule:
         backbone_direction = np.array([0, 0, 1])
         for mol in self.molecules:
             if heavy_atoms_only:
-                positions = np.array(
-                    [
-                        p.xyz[0]
-                        for p in mol.particles()
-                        if p.element.symbol != "H"
-                    ]
-                )
+                try:
+                    positions = np.array(
+                        [
+                            p.xyz[0]
+                            for p in mol.particles()
+                            if p.element.symbol != "H"
+                        ]
+                    )
+                except AttributeError:
+                    positions = mol.xyz
+                    warnings.warn(
+                        "No element information found." 
+                        "Using all particle positions to fit backbone axis."
+                    )
             else:
                 positions = mol.xyz
             backbone = get_backbone_vector(positions)

--- a/flowermd/base/system.py
+++ b/flowermd/base/system.py
@@ -712,6 +712,13 @@ class Lattice(System):
     basis_vector : array-like, default [0.5, 0.5, 0]
         The vector between points in the unit cell.
 
+    Notes
+    -----
+    The system is built in a way that the long axis of the
+    molecules is aligned with the z direction, and the
+    lattice is made by repeating and translating in the 
+    x and y directions.
+
     """
 
     def __init__(

--- a/flowermd/base/system.py
+++ b/flowermd/base/system.py
@@ -716,7 +716,7 @@ class Lattice(System):
     -----
     The system is built in a way that the long axis of the
     molecules is aligned with the z direction, and the
-    lattice is made by repeating and translating in the 
+    lattice is made by repeating and translating in the
     x and y directions.
 
     """

--- a/flowermd/tests/base/test_system.py
+++ b/flowermd/tests/base/test_system.py
@@ -818,7 +818,7 @@ class TestSystem(BaseTest):
 
     def test_lattice_bead_spring(self):
         chains = LJChain(lengths=10, num_mols=32)
-        system = Lattice(molecules=chains, x=1, y=1, n=4)
+        Lattice(molecules=chains, x=1, y=1, n=4)
 
     def test_scale_charges(self, pps):
         pps_mol = pps(num_mols=5, lengths=5)

--- a/flowermd/tests/base/test_system.py
+++ b/flowermd/tests/base/test_system.py
@@ -10,7 +10,12 @@ from unyt import Unit
 
 from flowermd import Lattice, Pack
 from flowermd.internal.exceptions import ForceFieldError, ReferenceUnitError
-from flowermd.library import OPLS_AA, OPLS_AA_DIMETHYLETHER, OPLS_AA_PPS
+from flowermd.library import (
+    OPLS_AA,
+    OPLS_AA_DIMETHYLETHER,
+    OPLS_AA_PPS,
+    LJChain
+)
 from flowermd.tests import BaseTest
 
 
@@ -810,6 +815,10 @@ class TestSystem(BaseTest):
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
         assert system.reference_values.keys() == {"energy", "length", "mass"}
+
+    def test_lattice_bead_spring(self):
+        chains = LJChain(lengths=10, num_mols=32)
+        system = Lattice(molecules=chains, x=1, y=1, n=4)
 
     def test_scale_charges(self, pps):
         pps_mol = pps(num_mols=5, lengths=5)

--- a/flowermd/tests/base/test_system.py
+++ b/flowermd/tests/base/test_system.py
@@ -14,7 +14,7 @@ from flowermd.library import (
     OPLS_AA,
     OPLS_AA_DIMETHYLETHER,
     OPLS_AA_PPS,
-    LJChain
+    LJChain,
 )
 from flowermd.tests import BaseTest
 

--- a/flowermd/tests/library/test_polymers.py
+++ b/flowermd/tests/library/test_polymers.py
@@ -41,18 +41,20 @@ class TestPolymers:
     def test_peek(self):
         chain = PEEK(lengths=5, num_mols=1)
         monomer = mb.load(chain.smiles, smiles=True)
-        assert chain.n_particles == (monomer.n_particles * 5) - 8
+        assert chain.n_particles == (monomer.n_particles * 5) - 8j
 
     def test_lj_chain(self):
         cg_chain = LJChain(
             lengths=3,
             num_mols=1,
-            bead_sequence=["A"],
-            bead_mass={"A": 100},
-            bond_lengths={"A-A": 1.5},
+            bead_sequence=["_A"],
+            bead_mass={"_A": 100},
+            bond_lengths={"_A-_A": 1.5},
         )
         assert cg_chain.n_particles == 3
         assert cg_chain.molecules[0].mass == 300
+        with pytest.warns():
+            cg_chain._align_backbones_z_axis(heavy_atoms_only=True)
 
     def test_lj_chain_sequence(self):
         cg_chain = LJChain(

--- a/flowermd/tests/library/test_polymers.py
+++ b/flowermd/tests/library/test_polymers.py
@@ -41,7 +41,7 @@ class TestPolymers:
     def test_peek(self):
         chain = PEEK(lengths=5, num_mols=1)
         monomer = mb.load(chain.smiles, smiles=True)
-        assert chain.n_particles == (monomer.n_particles * 5) - 8j
+        assert chain.n_particles == (monomer.n_particles * 5) - 8
 
     def test_lj_chain(self):
         cg_chain = LJChain(


### PR DESCRIPTION
This fixes #128 by adding a try/except statement to `Molecule._align_backbones_z_axis` in the case that the particles don't have elements.