### PR TITLE
Update MacOS images used in os-matrix in CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macos-latest, macOS-13, ubuntu-latest]
         python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
`macos-latest` switched to using ARM-based MacOS, so if we want to test on intel MacOS we have to use macos-13. This PR makes it so we now use both.