### PR TITLE
Add support for mBuild's periodic polymer bonding

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         environment-file: environment-dev.yml
         python-version: ${{ matrix.python-version }}
@@ -56,7 +56,7 @@ jobs:
       run: python -m pytest -rs -v --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/flowermd/base/molecule.py
+++ b/flowermd/base/molecule.py
@@ -478,7 +478,7 @@ class Polymer(Molecule):
     bond_orientation: list, default None
         The orientation of the bond between connected atoms.
     periodic_bond_axis : str, default None
-        Axis along which to orient the polymer backbone along.
+        Axis which to orient the polymer backbone along.
         Once the chain is aligned, a periodic bond between
         head and tail atoms is formed.
         Options are "x", "y", or "z"
@@ -521,6 +521,13 @@ class Polymer(Molecule):
 
     def _build(self, length):
         if self.periodic_bond_axis:
+            if not isinstance(
+                self.periodic_bond_axis, str
+            ) or self.periodic_bond_axis.lower() not in ["x", "y", "z"]:
+                raise ValueError(
+                    "Valid choices for a `periodic_bond_axis` are "
+                    "'x', 'y', 'z'"
+                )
             add_hydrogens = False
         else:
             add_hydrogens = True

--- a/flowermd/base/molecule.py
+++ b/flowermd/base/molecule.py
@@ -477,6 +477,11 @@ class Polymer(Molecule):
         The bond length between connected atoms (units: nm)
     bond_orientation: list, default None
         The orientation of the bond between connected atoms.
+    periodic_bond_axis : str, default None
+        Axis along which to orient the polymer backbone along.
+        Once the chain is aligned, a periodic bond between
+        head and tail atoms is formed.
+        Options are "x", "y", or "z"
 
     """
 
@@ -490,12 +495,14 @@ class Polymer(Molecule):
         bond_indices=None,
         bond_length=None,
         bond_orientation=None,
+        periodic_bond_axis=None,
         **kwargs,
     ):
         self.lengths = check_return_iterable(lengths)
         self.bond_indices = bond_indices
         self.bond_length = bond_length
         self.bond_orientation = bond_orientation
+        self.periodic_bond_axis = periodic_bond_axis
         num_mols = check_return_iterable(num_mols)
         if len(num_mols) != len(self.lengths):
             raise ValueError("Number of molecules and lengths must be equal.")
@@ -513,6 +520,10 @@ class Polymer(Molecule):
         return self._mb_molecule
 
     def _build(self, length):
+        if self.periodic_bond_axis:
+            add_hydrogens = False
+        else:
+            add_hydrogens = True
         chain = mbPolymer()
         chain.add_monomer(
             self.monomer,
@@ -520,7 +531,9 @@ class Polymer(Molecule):
             separation=self.bond_length,
             orientation=self.bond_orientation,
         )
-        chain.build(n=length, sequence="A")
+        chain.build(n=length, sequence="A", add_hydrogens=add_hydrogens)
+        if self.periodic_bond_axis:
+            chain.create_periodic_bond(axis=self.periodic_bond_axis)
         return chain
 
     def _generate(self):

--- a/flowermd/base/system.py
+++ b/flowermd/base/system.py
@@ -724,6 +724,10 @@ class Lattice(System):
     lattice is made by repeating and translating in the
     x and y directions.
 
+    See the `periodic_bond_axis` paramter in `flowermd.base.Polymer`
+    if you wish to form head-tail bonds across the periodic boundary
+    in the lattice.
+
     """
 
     def __init__(

--- a/flowermd/tests/base/test_molecule.py
+++ b/flowermd/tests/base/test_molecule.py
@@ -306,18 +306,16 @@ class TestCopolymer(BaseTest):
         for mol in pe.molecules:
             backbone = get_backbone_vector(mol.xyz)
             assert np.allclose(np.abs(backbone), np.array([0, 0, 1]), atol=1e-1)
-    
+
     @pytest.mark.parametrize("axis", ["x", "y", "z"])
     def test_periodic_bond(self, polyethylene, axis):
         pe_no_bond = polyethylene(num_mols=1, lengths=20)
         n_bonds = pe_no_bond.molecules[0].n_bonds
         n_particles = pe_no_bond.molecules[0].n_particles
         pe_with_bond = polyethylene(
-                num_mols=1,
-                lengths=20,
-                periodic_bond_axis=axis
+            num_mols=1, lengths=20, periodic_bond_axis=axis
         )
         n_bonds_with = pe_with_bond.molecules[0].n_bonds
         n_particles_with = pe_with_bond.molecules[0].n_particles
-        assert n_bonds - n_bonds_with == 1 
+        assert n_bonds - n_bonds_with == 1
         assert n_particles - n_particles_with == 2

--- a/flowermd/tests/base/test_molecule.py
+++ b/flowermd/tests/base/test_molecule.py
@@ -306,3 +306,18 @@ class TestCopolymer(BaseTest):
         for mol in pe.molecules:
             backbone = get_backbone_vector(mol.xyz)
             assert np.allclose(np.abs(backbone), np.array([0, 0, 1]), atol=1e-1)
+    
+    @pytest.mark.parametrize("axis", ["x", "y", "z"])
+    def test_periodic_bond(self, polyethylene, axis):
+        pe_no_bond = polyethylene(num_mols=1, lengths=20)
+        n_bonds = pe_no_bond.molecules[0].n_bonds
+        n_particles = pe_no_bond.molecules[0].n_particles
+        pe_with_bond = polyethylene(
+                num_mols=1,
+                lengths=20,
+                periodic_bond_axis=axis
+        )
+        n_bonds_with = pe_with_bond.molecules[0].n_bonds
+        n_particles_with = pe_with_bond.molecules[0].n_particles
+        assert n_bonds - n_bonds_with == 1 
+        assert n_particles - n_particles_with == 2

--- a/flowermd/tests/base/test_molecule.py
+++ b/flowermd/tests/base/test_molecule.py
@@ -319,3 +319,9 @@ class TestCopolymer(BaseTest):
         n_particles_with = pe_with_bond.molecules[0].n_particles
         assert n_bonds - n_bonds_with == 1
         assert n_particles - n_particles_with == 2
+
+    def test_periodic_bond_bad_axis(self, polyethylene):
+        with pytest.raises(ValueError):
+            polyethylene(num_mols=1, lengths=20, periodic_bond_axis=1)
+        with pytest.raises(ValueError):
+            polyethylene(num_mols=1, lengths=20, periodic_bond_axis="a")


### PR DESCRIPTION
The polymer builder in mBuild now lets you form periodic bonds, which basically just means you can bond the head and tail ports together. This should be useful for simulating polymer lattices where we want bonds formed across the the chain length direction.

This PR adds an option to the `Polymer` class that lets you use this built in feature in mBuild