### PR TITLE
Add data structure to save and restart a simulation.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         environment-file: environment-dev.yml
         python-version: ${{ matrix.python-version }}
@@ -56,7 +56,7 @@ jobs:
       run: python -m pytest -rs -v --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -166,11 +166,14 @@ class Simulation(hoomd.simulation.Simulation):
 
         state = data["state"]
         forces = data["forcefield"]
+        for force in forces:
+            if isinstance(force, hoomd.md.external.wall.LJ):
+                pass
         ref_values = data["reference_values"]
         sim_kwargs = data["sim_kwargs"]
         return cls(
             initial_state=state,
-            forcefield=forces,
+            forcefield=list(forces),
             reference_values=ref_values,
             **sim_kwargs,
         )

--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -1077,7 +1077,7 @@ class Simulation(hoomd.simulation.Simulation):
         if self._wall_forces and save_walls is False:
             forces = []
             for force in self._forcefield:
-                if not hasattr(force, "wall"):
+                if not isinstance(force, hoomd.md.external.wall.LJ):
                     forces.append(force)
         else:
             forces = self._forcefield
@@ -1163,7 +1163,7 @@ class Simulation(hoomd.simulation.Simulation):
         if self._wall_forces and save_walls is False:
             forces = []
             for force in self._forcefield:
-                if not hasattr(force, "wall"):
+                if not isinstance(force, hoomd.md.external.wall.LJ):
                     forces.append(force)
         else:
             forces = self._forcefield

--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -168,7 +168,18 @@ class Simulation(hoomd.simulation.Simulation):
         forces = data["forcefield"]
         for force in forces:
             if isinstance(force, hoomd.md.external.wall.LJ):
-                pass
+                new_walls = []
+                for _wall in force.walls:
+                    new_walls.append(
+                        hoomd.wall.Plane(
+                            origin=_wall.origin, normal=_wall.normal
+                        )
+                    )
+                new_wall = hoomd.md.external.wall.LJ(walls=new_walls)
+                for param in force.params:
+                    new_wall.params[param] = force.params[param]
+                forces.remove(force)
+                forces.append(new_wall)
         ref_values = data["reference_values"]
         sim_kwargs = data["sim_kwargs"]
         return cls(

--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -1142,7 +1142,7 @@ class Simulation(hoomd.simulation.Simulation):
         """
         hoomd.write.GSD.write(self.state, filename=file_path)
 
-    def save_simulation(self, file_path="simulation.pickle", save_walls=False):
+    def save_simulation(self, file_path="simulation.pickle"):
         """Save a pickle file with everything needed to retart a simulation.
 
         This method is useful for saving the state of a simulation to a file
@@ -1153,8 +1153,6 @@ class Simulation(hoomd.simulation.Simulation):
         ----------
         file_path : str, default "simulation.pickle"
             The path to save the pickle file to.
-        save_walls : bool, default False
-            Determines if any wall forces are saved.
 
         Notes
         -----
@@ -1166,21 +1164,7 @@ class Simulation(hoomd.simulation.Simulation):
             'forcefield': list of hoomd forces
             'state': gsd.hoomd.Frame
             'sim_kwargs': dict of flowermd.base.Simulation kwargs
-
-        Wall forces are not able to be reused when starting
-        a simulation. If your simulation has wall forces,
-        set `save_walls` to `False` and manually re-add them
-        in the new simulation if needed.
-
         """
-        # Make list of forces
-        if self._wall_forces and save_walls is False:
-            forces = []
-            for force in self._forcefield:
-                if not isinstance(force, hoomd.md.external.wall.LJ):
-                    forces.append(force)
-        else:
-            forces = self._forcefield
         # Make a temp restart gsd file.
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_file_path = os.path.join(tmp_dir, "temp.gsd")
@@ -1199,7 +1183,7 @@ class Simulation(hoomd.simulation.Simulation):
         # Create the final dict that holds everything.
         sim_dict = {
             "reference_values": self.reference_values,
-            "forcefield": forces,
+            "forcefield": self._forcefield,
             "state": snap,
             "sim_kwargs": sim_kwargs,
         }

--- a/flowermd/tests/base/test_simulation.py
+++ b/flowermd/tests/base/test_simulation.py
@@ -70,6 +70,18 @@ class TestSimulate(BaseTest):
         )
         new_sim.run_NVT(n_steps=2, kT=1.0, tau_kt=0.001)
 
+    def test_initialize_from_simulation_pickle_with_walls(self, benzene_system):
+        sim = Simulation.from_snapshot_forces(
+            initial_state=benzene_system.hoomd_snapshot,
+            forcefield=benzene_system.hoomd_forcefield,
+            reference_values=benzene_system.reference_values,
+        )
+        sim.add_walls(wall_axis=(1, 0, 0), sigma=1, epsilon=1, r_cut=1)
+        sim.save_simulation("simulation.pickle")
+        new_sim = Simulation.from_simulation_pickle("simulation.pickle")
+        assert len(new_sim.forces) == len(sim.forces)
+        new_sim.run_NVT(n_steps=2, kT=1.0, tau_kt=0.001)
+
     def test_initialize_from_bad_pickle(self, benzene_system):
         sim = Simulation.from_snapshot_forces(
             initial_state=benzene_system.hoomd_snapshot,


### PR DESCRIPTION
This PR adds `Simulation.save_simulation_pickle` and `Simulation.from_simulation_pickle` methods that save everything needed to save and restart a simulation (state, forces, reference values, and kwargs).

A couple notes:

1. The `save_simulation_pickle` method writes a binary string to the file that is checked by `from_simulation_pickle` before opening the pickle with `pickle.load`.

2. Using local snapshots, or `state.get_snapshot()` aren't pickleable, so we have to save a `temp.gsd.` file, then pickle the `gsd.hoomd.Frame` state instead.