### PR TITLE
Add method to save rigid constraints for ellipsoids

### DIFF
--- a/flowermd/base/simulation.py
+++ b/flowermd/base/simulation.py
@@ -1184,6 +1184,7 @@ class Simulation(hoomd.simulation.Simulation):
             "log_write_freq": self.log_write_freq,
             "gsd_max_buffer_size": self.maximum_write_buffer_size,
             "seed": self.seed,
+            "constraint": self.constraint,
         }
         # Create the final dict that holds everything.
         sim_dict = {


### PR DESCRIPTION
The simulations of ellipsoids require a rigid constraint from the system. A method is needed to save the rigid constraint for restarting a simulation.