### PR TITLE
Update nlist handling to match GMSO changes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build environment
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: environment-dev.yml
         create-args: >-
@@ -54,7 +54,7 @@ jobs:
       run: python -m pytest -rs -v --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
@@ -94,10 +94,10 @@ jobs:
         PR_NUMBER: ${{ github.event.issue.number }}
 
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build environment
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: environment-dev.yml
         create-args: >-

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - foyer >=1.0
   - freud >=3.4
   - gmso >=0.16.2
-  - gsd >=3.0
+  - gsd >=3.0,<5
   - grits >=0.6.0
   - hoomd>=5.0,!=5.3.0
   - mbuild >=1.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,9 +5,9 @@ dependencies:
   - foyer >=1.0
   - freud >=3.4
   - gmso >=0.16.2
-  - gsd >=3.0,<5
+  - gsd >=3.0
   - grits >=0.6.0
-  - hoomd>=5.0,!=5.3.0,<7
+  - hoomd>=5.0,!=5.3.0
   - mbuild >=1.0
   - numpy >=2.0
   - openbabel >=3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - foyer >=1.0
   - freud >=3.4
-  - gmso >=0.16.1
+  - gmso >=0.16.2
   - gsd >=3.0,<5
   - grits >=0.6.0
   - hoomd>=5.0,!=5.3.0,<7

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - foyer >=1.0
   - freud >=3.4
-  - gmso >=0.15.0
+  - gmso >=0.16.1
   - gsd >=3.0,<5
   - grits >=0.6.0
   - hoomd>=5.0,!=5.3.0,<7

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,9 +5,9 @@ dependencies:
   - foyer >=1.0
   - freud >=3.4
   - gmso >=0.15.0
-  - gsd >=3.0
+  - gsd >=3.0,<5
   - grits >=0.6.0
-  - hoomd>=5.0,!=5.3.0
+  - hoomd>=5.0,!=5.3.0,<7
   - mbuild >=1.0
   - numpy >=2.0
   - openbabel >=3

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - foyer >=1.0
   - freud >=3.4
   - gmso >=0.16.2
-  - gsd >=3.0
+  - gsd >=3.0,<5
   - grits >=0.5.1
   - hoomd>=5.0,!=5.3.0
   - mbuild >=1.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - foyer >=1.0
   - freud >=3.4
-  - gmso >=0.16.1
+  - gmso >=0.16.2
   - gsd >=3.0,<5
   - grits >=0.5.1
   - hoomd>=5.0,!=5.3.0,<7

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,9 @@ dependencies:
   - foyer >=1.0
   - freud >=3.4
   - gmso >=0.16.2
-  - gsd >=3.0,<5
+  - gsd >=3.0
   - grits >=0.5.1
-  - hoomd>=5.0,!=5.3.0,<7
+  - hoomd>=5.0,!=5.3.0
   - mbuild >=1.0
   - numpy >=2.0
   - openbabel >=3

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,9 @@ dependencies:
   - foyer >=1.0
   - freud >=3.4
   - gmso >=0.15.0
-  - gsd >=3.0
+  - gsd >=3.0,<5
   - grits >=0.5.1
-  - hoomd>=5.0,!=5.3.0
+  - hoomd>=5.0,!=5.3.0,<7
   - mbuild >=1.0
   - numpy >=2.0
   - openbabel >=3

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - foyer >=1.0
   - freud >=3.4
-  - gmso >=0.15.0
+  - gmso >=0.16.1
   - gsd >=3.0,<5
   - grits >=0.5.1
   - hoomd>=5.0,!=5.3.0,<7

--- a/flowermd/base/system.py
+++ b/flowermd/base/system.py
@@ -413,13 +413,13 @@ class System(ABC):
         topology.identify_connections()
         return topology
 
-    def _create_hoomd_forcefield(self, r_cut, nlist_buffer, pppm_kwargs):
+    def _create_hoomd_forcefield(self, r_cut, nlist, pppm_kwargs):
         """Create a list of HOOMD forces."""
         force_list = []
         ff, refs = to_hoomd_forcefield(
             top=self.gmso_system,
             r_cut=r_cut,
-            nlist_buffer=nlist_buffer,
+            nlist=nlist,
             pppm_kwargs=pppm_kwargs,
             auto_scale=False,
             base_units=(
@@ -504,7 +504,7 @@ class System(ABC):
         remove_hydrogens=False,
         pppm_resolution=(8, 8, 8),
         pppm_order=4,
-        nlist_buffer=0.4,
+        nlist=None,
         speedup_by_moltag=True,
         speedup_by_molgraph=False,
     ):
@@ -538,8 +538,11 @@ class System(ABC):
             The order used in
             `hoomd.md.long_range.pppm.make_pppm_coulomb_force` representing
             number of grid points in each direction to assign charges to.
-        nlist_buffer : float, default=0.4
-            Neighborlist buffer for simulation cell.
+        nlist : hoomd.md.nlist.Neighborlist, default None
+            Neighborlist instance for simulation cell.
+            If None, a cell nlist will be created by default using the
+            exclusions set by the foyer/GMSO forcefield.
+            see gmso.externl.convert_hoomd.py
         speedup_by_molgraph: bool, optional, default=False
             A flag to determine whether or not to search the system for repeated disconnected
             structures, otherwise known as molecules and type each molecule only once.
@@ -603,11 +606,11 @@ class System(ABC):
         pppm_kwargs = {"resolution": pppm_resolution, "order": pppm_order}
         self._ff_kwargs = {
             "r_cut": r_cut,
-            "nlist_buffer": nlist_buffer,
+            "nlist": nlist,
             "pppm_kwargs": pppm_kwargs,
         }
         self._hoomd_forcefield = self._create_hoomd_forcefield(
-            r_cut=r_cut, nlist_buffer=nlist_buffer, pppm_kwargs=pppm_kwargs
+            r_cut=r_cut, nlist=nlist, pppm_kwargs=pppm_kwargs
         )
         self._hoomd_snapshot = self._create_hoomd_snapshot()
 

--- a/flowermd/tests/base/test_simulation.py
+++ b/flowermd/tests/base/test_simulation.py
@@ -81,11 +81,15 @@ class TestSimulate(BaseTest):
         assert new_sim.gsd_write_freq == sim.gsd_write_freq
         assert new_sim.log_write_freq == sim.log_write_freq
         assert new_sim.seed == sim.seed
-        assert (
-            new_sim.maximum_write_buffer_size == sim.maximum_write_buffer_size
+        assert np.allclose(
+            new_sim.maximum_write_buffer_size,
+            sim.maximum_write_buffer_size,
+            atol=1e-4,
         )
-        assert new_sim.volume_reduced == sim.volume_reduced
-        assert new_sim.mass_reduced == sim.mass_reduced
+        assert np.allclose(
+            new_sim.volume_reduced, sim.volume_reduced, atol=1e-5
+        )
+        assert np.allclose(new_sim.mass_reduced, sim.mass_reduced, atol=1e-5)
         assert new_sim.reference_mass == sim.reference_mass
         assert new_sim.reference_energy == sim.reference_energy
         assert new_sim.reference_length == sim.reference_length

--- a/flowermd/tests/base/test_system.py
+++ b/flowermd/tests/base/test_system.py
@@ -810,12 +810,12 @@ class TestSystem(BaseTest):
             r_cut=2.5,
             force_field=[OPLS_AA()],
             auto_scale=False,
-            nlist_buffer=0.5,
+            nlist=hoomd.md.nlist.Cell(buffer=0.5),
             pppm_resolution=(4, 4, 4),
             pppm_order=3,
         )
         assert system._ff_kwargs["r_cut"] == 2.5
-        assert system._ff_kwargs["nlist_buffer"] == 0.5
+        assert isinstance(system._ff_kwargs["nlist"], hoomd.md.nlist.Cell)
         assert system._ff_kwargs["pppm_kwargs"]["resolution"] == (4, 4, 4)
         assert system._ff_kwargs["pppm_kwargs"]["order"] == 3
 


### PR DESCRIPTION
A recent PR in GMSO changes how the neighbor list is defined. Before, you passed in values for the parameters the neighbor list expects, and it was created for you, now it expects a hoomd neighbor list. This PR makes the necessary updates on the flowerMD side and pins to the latest version of GMSO.  